### PR TITLE
allow interleaving of scopes

### DIFF
--- a/dep0/lib/02_parser/test/dep0_parser_tests_0023_references.cpp
+++ b/dep0/lib/02_parser/test/dep0_parser_tests_0023_references.cpp
@@ -280,6 +280,7 @@ BOOST_AUTO_TEST_CASE(pass_011) { BOOST_TEST(pass("0023_references/pass_011.depc"
 BOOST_AUTO_TEST_CASE(pass_012) { BOOST_TEST(pass("0023_references/pass_012.depc")); }
 BOOST_AUTO_TEST_CASE(pass_013) { BOOST_TEST(pass("0023_references/pass_013.depc")); }
 BOOST_AUTO_TEST_CASE(pass_014) { BOOST_TEST(pass("0023_references/pass_014.depc")); }
+BOOST_AUTO_TEST_CASE(pass_015) { BOOST_TEST(pass("0023_references/pass_015.depc")); }
 
 BOOST_AUTO_TEST_CASE(typecheck_error_000)
 {

--- a/dep0/lib/03_typecheck/src/type_assign.cpp
+++ b/dep0/lib/03_typecheck/src/type_assign.cpp
@@ -361,7 +361,7 @@ type_assign(
         },
         [&] (parser::expr_t::pi_t const& pi) -> expected<expr_t>
         {
-            auto pi_ctx = ctx.extend();
+            auto pi_ctx = ctx.extend_scoped();
             return check_pi_type(env, pi_ctx, loc, pi.is_mutable, pi.args, pi.ret_type.get());
         },
         [&] (parser::expr_t::sigma_t const& sigma) -> expected<expr_t>
@@ -682,7 +682,7 @@ expected<expr_t> type_assign_abs(
     usage_t& usage,
     ast::qty_t const usage_multiplier)
 {
-    auto f_ctx = ctx.extend();
+    auto f_ctx = ctx.extend_scoped();
     auto func_type = check_pi_type(env, f_ctx, location, f.is_mutable, f.args, f.ret_type.get());
     if (not func_type)
         return std::move(func_type.error());

--- a/dep0/lib/03_typecheck/test/dep0_typecheck_tests_0023_references.cpp
+++ b/dep0/lib/03_typecheck/test/dep0_typecheck_tests_0023_references.cpp
@@ -111,6 +111,7 @@ BOOST_AUTO_TEST_CASE(pass_011) { BOOST_TEST(pass("0023_references/pass_011.depc"
 BOOST_AUTO_TEST_CASE(pass_012) { BOOST_TEST(pass("0023_references/pass_012.depc")); }
 BOOST_AUTO_TEST_CASE(pass_013) { BOOST_TEST(pass("0023_references/pass_013.depc")); }
 BOOST_AUTO_TEST_CASE(pass_014) { BOOST_TEST(pass("0023_references/pass_014.depc")); }
+BOOST_AUTO_TEST_CASE(pass_015) { BOOST_TEST(pass("0023_references/pass_015.depc")); }
 
 BOOST_AUTO_TEST_CASE(typecheck_error_000) { BOOST_TEST(fail("0023_references/typecheck_error_000.depc")); }
 BOOST_AUTO_TEST_CASE(typecheck_error_001) { BOOST_TEST(fail("0023_references/typecheck_error_001.depc")); }

--- a/dep0/lib/05_llvmgen/test/dep0_llvmgen_tests_0023_references.cpp
+++ b/dep0/lib/05_llvmgen/test/dep0_llvmgen_tests_0023_references.cpp
@@ -704,5 +704,6 @@ BOOST_AUTO_TEST_CASE(pass_011)
 BOOST_AUTO_TEST_CASE(pass_012) { BOOST_TEST(pass("0023_references/pass_012.depc")); }
 BOOST_AUTO_TEST_CASE(pass_013) { BOOST_TEST(pass("0023_references/pass_013.depc")); }
 BOOST_AUTO_TEST_CASE(pass_014) { BOOST_TEST(pass("0023_references/pass_014.depc")); }
+BOOST_AUTO_TEST_CASE(pass_015) { BOOST_TEST(pass("0023_references/pass_015.depc")); }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/testfiles/0023_references/pass_015.depc
+++ b/testfiles/0023_references/pass_015.depc
@@ -1,0 +1,8 @@
+/*
+ * Copyright Raffaele Rossi 2025.
+ *
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt)
+ */
+func f(i8_t x, ref_t(i8_t, scopeof(x)) p) -> i8_t { return *p; }
+func g() -> (i8_t x, ref_t(i8_t, scopeof(x)) p) -> i8_t { return f; }


### PR DESCRIPTION
Fixes #87

Before the typing rules involved a typing context with strict layering between scoped and unscoped contexts, where scoped context could only appear before unscoped ones; once an unscoped context was open, no more scoped context could be open. This change effectively changes the typing rules by allowing any alternating sequence of scoped and unscoped contexts.